### PR TITLE
feat(seo): add FAQPage & BreadcrumbList JSON-LD, use CreativeWork for…

### DIFF
--- a/app/components/FAQSection.tsx
+++ b/app/components/FAQSection.tsx
@@ -2,11 +2,7 @@
 
 import { useState } from 'react';
 import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
-
-interface FAQ {
-  question: string;
-  answer: string;
-}
+import type { FAQ } from '../data/faqs';
 
 interface FAQSectionProps {
   faqs: FAQ[];
@@ -97,38 +93,3 @@ export default function FAQSection({
     </section>
   );
 }
-
-// Default FAQs for the site
-/** Default set of frequently asked questions addressing common client concerns. */
-export const defaultFAQs: FAQ[] = [
-  {
-    question: 'What is the typical process for a project?',
-    answer:
-      'Every project follows four stages: Brief, Sketch & Concept, Iteration, and Delivery. We start with a conversation to understand your research context, audience, and goals. I then develop initial sketches or wireframes for your review, refine through structured feedback rounds, and deliver final files in all required formats. The process ensures you stay involved at every step without needing to manage the details.',
-  },
-  {
-    question: 'How long does a project usually take?',
-    answer:
-      'Timelines vary by scope. A single scientific illustration typically takes 1\u20132 weeks. Brand identity projects run 3\u20134 weeks. Web platforms range from 4\u201312 weeks depending on complexity. During the initial brief, I provide a clear timeline estimate so you can plan accordingly. Urgent requests are possible \u2014 just let me know your deadline.',
-  },
-  {
-    question: 'Do you work remotely and internationally?',
-    answer:
-      'Yes, most of my collaborations are remote. I currently work with institutions and researchers across the Netherlands, Austria, Switzerland, India, and the United States. Communication happens via email, video calls, and shared project boards \u2014 whatever works best for your team.',
-  },
-  {
-    question: 'Are you a vendor or a collaborator?',
-    answer:
-      'A collaborator. As a trained landscape archaeologist, I understand research workflows, publication standards, and the importance of accuracy. I work as a partner embedded in your project, not an external service provider who needs everything spelled out. This means fewer misunderstandings and results that genuinely serve your research.',
-  },
-  {
-    question: 'Can you work with our existing research data or systems?',
-    answer:
-      'Absolutely. I regularly work with GIS data, archaeological databases like OpenAtlas, archival systems, IIIF image servers, and various data formats. If you have existing datasets, CMS platforms, or institutional design guidelines, I integrate with what you already have rather than starting from scratch.',
-  },
-  {
-    question: 'What if I am not sure which service I need?',
-    answer:
-      'That is completely fine and quite common. Many projects cross service boundaries \u2014 a research platform might need illustrations, a publication might need web components. Book a free consultation and I will help you figure out the best approach for your goals and budget.',
-  },
-];

--- a/app/data/faqs.ts
+++ b/app/data/faqs.ts
@@ -1,0 +1,38 @@
+export interface FAQ {
+  question: string;
+  answer: string;
+}
+
+/** Default set of frequently asked questions addressing common client concerns. */
+export const defaultFAQs: FAQ[] = [
+  {
+    question: 'What is the typical process for a project?',
+    answer:
+      'Every project follows four stages: Brief, Sketch & Concept, Iteration, and Delivery. We start with a conversation to understand your research context, audience, and goals. I then develop initial sketches or wireframes for your review, refine through structured feedback rounds, and deliver final files in all required formats. The process ensures you stay involved at every step without needing to manage the details.',
+  },
+  {
+    question: 'How long does a project usually take?',
+    answer:
+      'Timelines vary by scope. A single scientific illustration typically takes 1\u20132 weeks. Brand identity projects run 3\u20134 weeks. Web platforms range from 4\u201312 weeks depending on complexity. During the initial brief, I provide a clear timeline estimate so you can plan accordingly. Urgent requests are possible \u2014 just let me know your deadline.',
+  },
+  {
+    question: 'Do you work remotely and internationally?',
+    answer:
+      'Yes, most of my collaborations are remote. I currently work with institutions and researchers across the Netherlands, Austria, Switzerland, India, and the United States. Communication happens via email, video calls, and shared project boards \u2014 whatever works best for your team.',
+  },
+  {
+    question: 'Are you a vendor or a collaborator?',
+    answer:
+      'A collaborator. As a trained landscape archaeologist, I understand research workflows, publication standards, and the importance of accuracy. I work as a partner embedded in your project, not an external service provider who needs everything spelled out. This means fewer misunderstandings and results that genuinely serve your research.',
+  },
+  {
+    question: 'Can you work with our existing research data or systems?',
+    answer:
+      'Absolutely. I regularly work with GIS data, archaeological databases like OpenAtlas, archival systems, IIIF image servers, and various data formats. If you have existing datasets, CMS platforms, or institutional design guidelines, I integrate with what you already have rather than starting from scratch.',
+  },
+  {
+    question: 'What if I am not sure which service I need?',
+    answer:
+      'That is completely fine and quite common. Many projects cross service boundaries \u2014 a research platform might need illustrations, a publication might need web components. Book a free consultation and I will help you figure out the best approach for your goals and budget.',
+  },
+];

--- a/app/lib/seo.ts
+++ b/app/lib/seo.ts
@@ -104,8 +104,8 @@ export function generateSEOMetadata({
   return metadata;
 }
 
-/** Creates JSON-LD structured data for an article page. */
-export function generateArticleStructuredData({
+/** Creates JSON-LD structured data for a creative work / portfolio project page. */
+export function generateCreativeWorkStructuredData({
   title,
   description,
   author = 'Jona Schlegel',
@@ -126,15 +126,10 @@ export function generateArticleStructuredData({
 }) {
   return {
     '@context': 'https://schema.org',
-    '@type': 'Article',
-    headline: title,
+    '@type': 'CreativeWork',
+    name: title,
     description,
     author: {
-      '@type': 'Person',
-      name: author,
-      url: 'https://jonaschlegel.com',
-    },
-    publisher: {
       '@type': 'Person',
       name: author,
       url: 'https://jonaschlegel.com',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,8 @@ import Banner from './components/Banner';
 import BlogPreview from './components/BlogPreview';
 import ClientLogos from './components/ClientLogos';
 import CurrentRoleBanner from './components/CurrentRoleBanner';
-import FAQSection, { defaultFAQs } from './components/FAQSection';
+import FAQSection from './components/FAQSection';
+import { defaultFAQs } from './data/faqs';
 import Hero from './components/Hero';
 import IllustrationBand from './components/IllustrationBand';
 import InstagramGrid from './components/InstagramGrid';
@@ -111,6 +112,24 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(podcastStructuredData),
+        }}
+      />
+      <script
+        id="faq-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: defaultFAQs.map((faq) => ({
+              '@type': 'Question',
+              name: faq.question,
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: faq.answer,
+              },
+            })),
+          }),
         }}
       />
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import BlogPreview from './components/BlogPreview';
 import ClientLogos from './components/ClientLogos';
 import CurrentRoleBanner from './components/CurrentRoleBanner';
 import FAQSection from './components/FAQSection';
-import { defaultFAQs } from './data/faqs';
 import Hero from './components/Hero';
 import IllustrationBand from './components/IllustrationBand';
 import InstagramGrid from './components/InstagramGrid';
@@ -14,8 +13,8 @@ import PodcastSection, {
   podcastStructuredData,
 } from './components/PodcastSection';
 import RecentActivity from './components/RecentActivity';
-import Services from './components/Services';
 import Testimonials from './components/Testimonials';
+import { defaultFAQs } from './data/faqs';
 import { generateSEOMetadata } from './lib/seo';
 
 /** SEO metadata for the home page. */

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -6,7 +6,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import ImageGallery from '../../components/ImageGallery';
 import { projectsData } from '../../data/content';
 import { generateProjectOGImageUrl } from '../../lib/og-utils';
-import { generateArticleStructuredData } from '../../lib/seo';
+import { generateBreadcrumbStructuredData, generateCreativeWorkStructuredData } from '../../lib/seo';
 
 interface ProjectPageProps {
   params: Promise<Params>;
@@ -54,14 +54,7 @@ export async function generateMetadata({
     title: { absolute: projectTitle },
     description: projectDescription,
     keywords: [
-      'archaeology project',
-      'archaeological illustration',
-      'archaeology web development',
       project.name.toLowerCase(),
-      'visual science communication',
-      'archaeological research',
-      'archaeology web design',
-      'freelance archaeological illustrator',
       ...project.services.map((s) => s.toLowerCase()),
       ...project.tools.map((t) => t.toLowerCase()),
       ...(project.location ? [project.location.toLowerCase()] : []),
@@ -295,12 +288,12 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
         </section>
       )}
 
-      {/* Article Structured Data */}
+      {/* CreativeWork Structured Data */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(
-            generateArticleStructuredData({
+            generateCreativeWorkStructuredData({
               title: project.name,
               description:
                 project.description ||
@@ -313,10 +306,21 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
               }),
               keywords: [
                 ...project.services,
-                'archaeology',
-                'science communication',
+                ...project.tools,
               ],
             }),
+          ).replace(/</g, '\u003c'),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            generateBreadcrumbStructuredData([
+              { name: 'Home', url: 'https://jonaschlegel.com' },
+              { name: 'Projects', url: 'https://jonaschlegel.com/projects' },
+              { name: project.name },
+            ]),
           ).replace(/</g, '\u003c'),
         }}
       />

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -6,7 +6,10 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import ImageGallery from '../../components/ImageGallery';
 import { projectsData } from '../../data/content';
 import { generateProjectOGImageUrl } from '../../lib/og-utils';
-import { generateBreadcrumbStructuredData, generateCreativeWorkStructuredData } from '../../lib/seo';
+import {
+  generateBreadcrumbStructuredData,
+  generateCreativeWorkStructuredData,
+} from '../../lib/seo';
 
 interface ProjectPageProps {
   params: Promise<Params>;
@@ -304,10 +307,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
                 description: project.description,
                 services: project.services,
               }),
-              keywords: [
-                ...project.services,
-                ...project.tools,
-              ],
+              keywords: [...project.services, ...project.tools],
             }),
           ).replace(/</g, '\u003c'),
         }}


### PR DESCRIPTION
… projects, clean up keywords

- Add server-rendered FAQPage JSON-LD on home page (moved FAQ data to shared data file to avoid client/server boundary issues)
- Remove duplicate client-side FAQ structured data from FAQSection
- Add BreadcrumbList JSON-LD to project detail pages
- Change project structured data from Article to CreativeWork (more accurate for portfolio case studies)
- Remove generic hardcoded keywords from project pages, keep only project-specific terms (name, services, tools, location)