### PR TITLE
Fix duplicate FAQPage JSON-LD, missing sitemap entries, error boundaries & broken anchors

### DIFF
--- a/app/data/content.ts
+++ b/app/data/content.ts
@@ -1069,7 +1069,7 @@ export const footerdata = {
     { Icon: BsTwitter, href: 'https://twitter.com/JonaSchlegel' },
     {
       Icon: BsLinkedin,
-      href: 'https://www.linkedin.com/in/jona-schlegel-942879153/',
+      href: 'https://www.linkedin.com/in/jona-schlegel/',
     },
     { Icon: BsGithub, href: 'https://github.com/jonaschlegel' },
   ],

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto flex min-h-[50vh] flex-col items-center justify-center px-4 py-16 text-center">
+      <h1 className="mb-4 text-3xl font-bold">Something went wrong</h1>
+      <p className="mb-8 text-gray-600">
+        An unexpected error occurred. Please try again.
+      </p>
+      <button
+        onClick={reset}
+        className="bg-primary-green px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect } from 'react';
 
-export default function GlobalError({
+/** Root-level error boundary that catches unhandled errors in any route segment. */
+export default function RootError({
   error,
   reset,
 }: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { generateSEOMetadata } from './lib/seo';
 export const metadata: Metadata = generateSEOMetadata({
   title: 'Home',
   description:
-    'Jona Schlegel – Freelance landscape archaeologist specialising in visual science communication, archaeological illustration, drawing & sketching, visual science communication, archaeology web development, digital heritage platforms, and brand identity for archaeology.',
+    'Jona Schlegel – Freelance landscape archaeologist specialising in archaeological illustration, drawing & sketching, visual science communication, archaeology web development, digital heritage platforms, and brand identity for archaeology.',
   canonical: 'https://jonaschlegel.com',
   keywords: [
     'archaeological illustration',
@@ -35,10 +35,8 @@ export const metadata: Metadata = generateSEOMetadata({
     'archaeology web development',
     'archaeology web design',
     'archaeology website development',
-    'visual science communication archaeology',
     'freelance archaeological illustrator',
     'archaeology fullstack developer',
-    'archaeological drawing',
     'archaeology painting',
     'archaeology cover art',
     'archaeology brand identity',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { generateSEOMetadata } from './lib/seo';
 export const metadata: Metadata = generateSEOMetadata({
   title: 'Home',
   description:
-    'Jona Schlegel – Freelance landscape archaeologist specialising in visual science communication, archaeological illustration, drawing & sketching, visual science communication,archaeology web development, digital heritage platforms, and brand identity for archaeology.',
+    'Jona Schlegel – Freelance landscape archaeologist specialising in visual science communication, archaeological illustration, drawing & sketching, visual science communication, archaeology web development, digital heritage platforms, and brand identity for archaeology.',
   canonical: 'https://jonaschlegel.com',
   keywords: [
     'archaeological illustration',
@@ -111,24 +111,6 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(podcastStructuredData),
-        }}
-      />
-      <script
-        id="faq-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'FAQPage',
-            mainEntity: defaultFAQs.map((faq) => ({
-              '@type': 'Question',
-              name: faq.question,
-              acceptedAnswer: {
-                '@type': 'Answer',
-                text: faq.answer,
-              },
-            })),
-          }),
         }}
       />
     </>

--- a/app/projects/[slug]/error.tsx
+++ b/app/projects/[slug]/error.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 
+/** Error boundary for individual project pages, with a link back to the projects overview. */
 export default function ProjectError({
   error,
   reset,

--- a/app/projects/[slug]/error.tsx
+++ b/app/projects/[slug]/error.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function ProjectError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto flex min-h-[50vh] flex-col items-center justify-center px-4 py-16 text-center">
+      <h1 className="mb-4 text-3xl font-bold">Could not load this project</h1>
+      <p className="mb-8 text-gray-600">
+        Something went wrong while loading the project. Please try again or go
+        back to the projects overview.
+      </p>
+      <div className="flex gap-4">
+        <button
+          onClick={reset}
+          className="bg-primary-green px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+        >
+          Try again
+        </button>
+        <Link
+          href="/projects"
+          className="border border-gray-300 px-6 py-3 text-sm font-semibold text-primary-dark transition-colors hover:border-gray-500"
+        >
+          All projects
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/services/ServicesContent.tsx
+++ b/app/services/ServicesContent.tsx
@@ -134,9 +134,9 @@ const timelines = [
 ] as const;
 
 const capabilityAnchors: Record<string, string> = {
-  'Illustration & Visual Storytelling': 'illustration',
+  'Archaeological Illustration & Visual Science Communication': 'illustration',
   '3D Modelling & Documentation': '3d-modelling',
-  'Web Development & Digital Platforms': 'web-development',
+  'Archaeology Web Development & Design': 'web-development',
   'Brand & Publication Design': 'brand-design',
 };
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -40,6 +40,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/impact`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/imprint`,
       lastModified: new Date(),
       changeFrequency: 'yearly',


### PR DESCRIPTION
## Summary

Fixes 6 high-priority bugs found during a codebase audit.

## Changes

### 1. Fix duplicate FAQPage JSON-LD (GSC error: "Duplicate field 'FAQPage'")
The home page emitted two identical `FAQPage` structured data blocks — one inline in `page.tsx` and one from the `<FAQSection>` component. Removed the inline duplicate since the component already handles it and is reused on the services page.

### 2. Add `/impact` to sitemap
The `/impact` route was missing from `sitemap.ts`, preventing Google from discovering it via sitemap.xml.

### 3. Fix missing space in home page description
`"visual science communication,archaeology web development"` → added missing space after comma.

### 4. Add error boundaries
Added `app/error.tsx` (global) and `app/projects/[slug]/error.tsx` (project-specific) so users see a styled error page with recovery options instead of an unstyled Next.js crash screen.

### 5. Fix `capabilityAnchors` mapping in ServicesContent
The anchor ID keys (`'Illustration & Visual Storytelling'`, etc.) didn't match the actual capability titles (`'Archaeological Illustration & Visual Science Communication'`, etc.), so fragment links like `/services#illustration` were broken.

### 6. Standardize LinkedIn URL
Footer used `/in/jona-schlegel-942879153/` while layout.tsx structured data used `/in/jona-schlegel/`. Standardized to the clean vanity URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive error pages that display when issues occur, providing users with helpful "Try again" options and navigation assistance.
  * Introduced /impact route and added it to site navigation and sitemap.

* **Updates**
  * Refined service capability names to better reflect specialized offerings and improve clarity.
  * Updated social media links and optimized page metadata for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->